### PR TITLE
Fix 10.14 Issue

### DIFF
--- a/Computer Information.bash
+++ b/Computer Information.bash
@@ -154,7 +154,7 @@ operatingSystem="Operating System: $runCommand"
 
 
 # Display battery cycle count
-runCommand=$( ioreg -r -c AppleSmartBattery | awk '$1=="\"CycleCount\"" {print $3}' )
+runCommand=$( /usr/sbin/ioreg -r -c AppleSmartBattery | awk '$1=="\"CycleCount\"" {print $3}' )
 batteryCycleCount="Battery Cycle Count: $runCommand"
 
 

--- a/Computer Information.bash
+++ b/Computer Information.bash
@@ -154,7 +154,7 @@ operatingSystem="Operating System: $runCommand"
 
 
 # Display battery cycle count
-runCommand=$( /usr/sbin/ioreg -r -c AppleSmartBattery | awk '$1=="\"CycleCount\"" {print $3}' )
+runCommand=$( /usr/sbin/ioreg -r -c AppleSmartBattery | /usr/bin/awk '$1=="\"CycleCount\"" {print $3}' )
 batteryCycleCount="Battery Cycle Count: $runCommand"
 
 

--- a/Computer Information.bash
+++ b/Computer Information.bash
@@ -154,7 +154,7 @@ operatingSystem="Operating System: $runCommand"
 
 
 # Display battery cycle count
-runCommand=$( /usr/sbin/ioreg -r -c "AppleSmartBattery" | /usr/bin/grep -w "CycleCount" | /usr/bin/awk '{print $3}' | /usr/bin/sed s/\"//g )
+runCommand=$( ioreg -r -c AppleSmartBattery | awk '$1=="\"CycleCount\"" {print $3}' )
 batteryCycleCount="Battery Cycle Count: $runCommand"
 
 


### PR DESCRIPTION
There was an issue on 10.14 where the cycle count grabbed far more than needed. I fixed this by using awk to find the cycle count, and then parse it.
An added benefit is reduced processing time, and less complex code.

**confirmed to work on: _10.14_**